### PR TITLE
Add a config file and a new config item

### DIFF
--- a/ezxml.h
+++ b/ezxml.h
@@ -28,7 +28,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "ezxml_cfg.h"
+
+#ifndef EZXML_NOT_PARSE_FILE
 #include <fcntl.h>
+#endif //EZXML_NOT_PARSE_FILE
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +63,7 @@ struct ezxml {
 // pass in the copy. Returns NULL on failure.
 ezxml_t ezxml_parse_str(char *s, size_t len);
 
+#ifndef EZXML_NOT_PARSE_FILE
 // A wrapper for ezxml_parse_str() that accepts a file descriptor. First
 // attempts to mem map the file. Failing that, reads the file into memory.
 // Returns NULL on failure.
@@ -66,11 +71,12 @@ ezxml_t ezxml_parse_fd(int fd);
 
 // a wrapper for ezxml_parse_fd() that accepts a file name
 ezxml_t ezxml_parse_file(const char *file);
-    
+
 // Wrapper for ezxml_parse_str() that accepts a file stream. Reads the entire
 // stream into memory and then parses it. For xml files, use ezxml_parse_file()
 // or ezxml_parse_fd()
 ezxml_t ezxml_parse_fp(FILE *fp);
+#endif //EZXML_NOT_PARSE_FILE
 
 // returns the first child tag (one level deeper) with the given name or NULL
 // if not found

--- a/ezxml_cfg.h
+++ b/ezxml_cfg.h
@@ -1,0 +1,42 @@
+/* ezxml_cfg.h
+ *
+ * Copyright 2017 Armink <armink.ztl@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef _EZXML_CFG_H
+#define _EZXML_CFG_H
+
+//You can define some configuare on this file. Such as:
+//
+//    #define EZXML_NOMMAP
+//    #define EZXML_NOT_PARSE_FILE
+//
+//    Memory management function configuare.
+//    Default is malloc, calloc, realloc and free on C Standard Library
+//    #define EZXML_MALLOC my_malloc
+//    #define EZXML_CALLOC my_calloc
+//    #define EZXML_REALLOC my_realloc
+//    #define EZXML_FREE my_free
+//
+//    String duplicate funciton. Default is strdup.
+//    #define EZXML_STRDUP my_strdup
+
+#endif /* _EZXML_CFG_H */


### PR DESCRIPTION
-  Add a config file: C standard memory management and string duplicate function may be not using on some embedded platform. So we need redefine it on header file.
- Add EZXML_NOT_PARSE_FILE config: When product platform not has file system. This config need to open.