### PR TITLE
fix([ezxml.c]/[ezxml_internal_dtd]): fix gcc compilation warning

### DIFF
--- a/ezxml.c
+++ b/ezxml.c
@@ -818,7 +818,7 @@ void ezxml_free(ezxml_t xml)
         }            
         if (root->pi[0]) free(root->pi); // free processing instructions
 
-        if (root->len == -1) free(root->m); // malloced xml data
+        if (root->len == (unsigned int)-1) free(root->m); // malloced xml data
 #ifndef EZXML_NOMMAP
         else if (root->len) munmap(root->m, root->len); // mem mapped xml data
 #endif // EZXML_NOMMAP

--- a/ezxml.c
+++ b/ezxml.c
@@ -360,8 +360,16 @@ short ezxml_internal_dtd(ezxml_root_t root, char *s, size_t len)
             if (*(s = t + strcspn(t, EZXML_WS ">")) == '>') continue;
             else *s = '\0'; // null terminate tag name
             for (i = 0; root->attr[i] && strcmp(n, root->attr[i][0]); i++);
-
-            while (*(n = ++s + strspn(s, EZXML_WS)) && *n != '>') {
+            /*============================================================
+            * description: start of fix gcc warning: pointer reference as
+              increment operator on 's' may be undefined, Apr 28th, 2023
+            * ============================================================*/
+            while (*n != '>') {
+                ++s;
+                if (*(n = s + strspn(s, EZXML_WS)) == 0) { break; }
+                /*====================================================
+                * description: end of fix gcc warning, Apr 28th, 2023
+                * ====================================================*/
                 if (*(s = n + strcspn(n, EZXML_WS))) *s = '\0'; // attr name
                 else { ezxml_err(root, t, "malformed <!ATTLIST"); break; }
 


### PR DESCRIPTION
fix gcc compilation warning due to accessing address of char *s after increment operation with inline condition expression.

Closed #6 
Closed #8 